### PR TITLE
Fixing issue with unlimited nodes in parser

### DIFF
--- a/lib/atlas/node.rb
+++ b/lib/atlas/node.rb
@@ -18,8 +18,9 @@ module Atlas
 
     attr_reader :children
 
-    def initialize(children = [])
-      @children = NodeChildren.new(children)
+    def initialize(initial_children = [])
+      @children = NodeChildren.new()
+      initial_children.each { |child| append(child) }
     end
 
     def limit
@@ -28,10 +29,9 @@ module Atlas
 
     def <<(child)
       if limit_reached?
-        raise ArityLimitError("Number of children limit reached (#{limit})")
+        raise ArityLimitError, "Number of children limit reached (#{limit})"
       else
-        child.parent = self
-        children << child
+        append(child)
       end
 
       self
@@ -39,6 +39,13 @@ module Atlas
 
     def limit_reached?
       children.length >= limit
+    end
+
+    private
+
+    def append(child)
+      child.parent = self
+      children << child
     end
   end
 

--- a/lib/atlas/node.rb
+++ b/lib/atlas/node.rb
@@ -19,7 +19,7 @@ module Atlas
     attr_reader :children
 
     def initialize(initial_children = [])
-      @children = NodeChildren.new()
+      @children = NodeChildren.new
       initial_children.each { |child| append(child) }
     end
 

--- a/lib/atlas/node_children.rb
+++ b/lib/atlas/node_children.rb
@@ -5,8 +5,8 @@ module Atlas
 
     delegate :<<, :length, to: :elements
 
-    def initialize(elements = [])
-      @elements = elements
+    def initialize
+      @elements = []
     end
 
     def each(&blk)

--- a/lib/atlas/parser.rb
+++ b/lib/atlas/parser.rb
@@ -69,7 +69,7 @@ module Atlas
           @current_node = current_node.parent
 
           # If the parent is also full, keep going up the ancestry
-          break unless @current_node.limit_reached?
+          break if !current_node || !current_node.limit_reached?
         end
       end
     end

--- a/lib/atlas/parser.rb
+++ b/lib/atlas/parser.rb
@@ -46,7 +46,7 @@ module Atlas
       when Atlas::OpeningGroupToken
         @current_node = group_stack.pop
       when Atlas::OpeningListToken
-        @current_node = current_node.parent
+        set_current_node_to_ancestor
       else
         process_child_node
       end
@@ -58,9 +58,18 @@ module Atlas
         current_node << node
 
         if current_node.limit_reached?
-          @current_node = current_node.parent
+          set_current_node_to_ancestor
         elsif !node.limit_reached?
           @current_node = node
+        end
+      end
+
+      def set_current_node_to_ancestor
+        loop do
+          @current_node = current_node.parent
+
+          # If the parent is also full, keep going up the ancestry
+          break unless @current_node.limit_reached?
         end
       end
     end

--- a/lib/atlas/plain/node.rb
+++ b/lib/atlas/plain/node.rb
@@ -42,10 +42,15 @@ module Atlas
       end
     end
 
+    class WrapperNode < UnaryFunctionNode
+      delegate :limit, :<<, :limit_reached?, to: :child
+    end
+
     {
+      WrapperNode => %w(Not),
       UnaryFunctionNode => %w(Exists),
-      BinaryFunctionNode => %w(Eq NotEq Lt Lte Gt Gte),
-      NAryFunctionNode => %w(And Or Includes Excludes),
+      BinaryFunctionNode => %w(Eq Lt Lte Gt Gte Includes),
+      NAryFunctionNode => %w(And Or),
     }.each do |klass, prefixes|
       prefixes.each do |prefix|
         class_def = Class.new(klass) do

--- a/lib/atlas/plain/parser.rb
+++ b/lib/atlas/plain/parser.rb
@@ -16,12 +16,13 @@ module Atlas
         when Atlas::ValueToken then ValueNode.new(token.value)
         when Atlas::ClosingListToken then ListNode.new
         when Atlas::ExistsToken then ExistsNode.new
+        when Atlas::NotExistsToken then NotNode.new([ExistsNode.new])
         when Atlas::AndToken then AndNode.new
         when Atlas::OrToken then OrNode.new
         when Atlas::EqToken then EqNode.new
-        when Atlas::NotEqToken then NotEqNode.new
+        when Atlas::NotEqToken then NotNode.new([EqNode.new])
         when Atlas::InToken then IncludesNode.new
-        when Atlas::NotInToken then ExcludesNode.new
+        when Atlas::NotInToken then NotNode.new([IncludesNode.new])
         when Atlas::LessThanToken then LtNode.new
         when Atlas::LessThanOrEqualToToken then LteNode.new
         when Atlas::GreaterThanToken then GtNode.new

--- a/lib/atlas/postfixer.rb
+++ b/lib/atlas/postfixer.rb
@@ -37,9 +37,15 @@ module Atlas
       when Atlas::ClosingGroupToken
         pop_grouped_operators
         push_to_values
-      when Atlas::ComparisonToken, Atlas::LogicalToken
+      when Atlas::ComparisonToken
         pop_precedent_operators
         push_to_operators
+      when Atlas::LogicalToken
+        pop_precedent_operators
+
+        # if there are multiple of the same logical operator, ignore new ones:
+        # "c1 AND c2 AND c3" should become "AND c1 c2 c3" instead of "AND AND c1 c2 c3"
+        push_to_operators unless token == top_operator
       when Atlas::ValueToken, Atlas::ListToken
         push_to_values
       end


### PR DESCRIPTION
The following query was causing issues:

```
foo EQ X AND bar NOTIN [c1, c2, c3]
```

while the following works:

```
bar NOTIN [c1, c2, c3] AND foo EQ X
```